### PR TITLE
updating to add v2 in more spots

### DIFF
--- a/doc/sphinx-guides/source/api/apps.rst
+++ b/doc/sphinx-guides/source/api/apps.rst
@@ -16,7 +16,7 @@ Data Explorer
 
 Data Explorer is a GUI which lists the variables in a tabular data file allowing searching, charting and cross tabulation analysis.
 
-https://github.com/scholarsportal/Dataverse-Data-Explorer
+https://github.com/scholarsportal/Dataverse-Data-Explorer-v2
 
 Data Curation Tool
 ~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -303,10 +303,7 @@ R
 Dataverse uses `R <https://https://cran.r-project.org/>`_ to handle
 tabular data files. The instructions below describe a **minimal** R
 installation. It will allow you to ingest R (.RData) files as tabular
-data; to export tabular data as .RData files; and to run `Data
-Explorer <https://github.com/scholarsportal/Dataverse-Data-Explorer>`_
-(specifically, R is used to generate .prep metadata files that Data
-Explorer uses).  R can be considered an optional component, meaning
+data and to export tabular data as .RData files.  R can be considered an optional component, meaning
 that if you don't have R installed, you will still be able to run and
 use Dataverse - but the functionality specific to tabular data
 mentioned above will not be available to your users.  **Note** that if

--- a/doc/sphinx-guides/source/installation/r-rapache-tworavens.rst
+++ b/doc/sphinx-guides/source/installation/r-rapache-tworavens.rst
@@ -27,7 +27,7 @@ correct versions of the required third party R packages.
 setup described in the "Prerequisites" portion of the Installation
 Guide. Meaning that once completed, it installs everything needed to
 run TwoRavens, PLUS all the libraries and components required to
-ingest RData files, export as RData, and use Data Explorer.**
+ingest RData files and export as RData.**
 
 
 

--- a/src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java
@@ -376,7 +376,7 @@ public class ExternalToolsIT {
         job.add("types", Json.createArrayBuilder().add("explore"));
         job.add("scope", "file");
         job.add("contentType", "text/tab-separated-values");
-        job.add("toolUrl", "https://scholarsportal.github.io/Dataverse-Data-Explorer/");
+        job.add("toolUrl", "https://scholarsportal.github.io/Dataverse-Data-Explorer-v2/");
         job.add("toolParameters", Json.createObjectBuilder()
                 .add("queryParameters", Json.createArrayBuilder()
                         .add(Json.createObjectBuilder()


### PR DESCRIPTION

Hey @kaitlinnewson - thanks for discussing Data Explorer V2 on the Community Call earlier today and thanks for putting up the PR to update the docs! During the review I noticed that there a few other spots that mention Data Explorer so I put up this PR to update. Feel free to merge this into your branch to capture the changes, or you can look at the files changed and make the changes on your branch yourself - up to you! Thank you again!

What this PR does:

- Adds V2 in a few more spots. See files changed for the diff. Out with the old, in with the new
- Removes the Data Explorer mentions for R, if I understand correctly that the .prep file is no longer needed

**Which issue(s) this PR closes**:

N/A

**Special notes for your reviewer**:

I made a non-doc change to src/test/java/edu/harvard/iq/dataverse/api/ExternalToolsIT.java, so we should make sure that works OK.

**Suggestions on how to test this**:

N/A

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

N/A

**Is there a release notes update needed for this change?**:

N/A

**Additional documentation**:

N/A